### PR TITLE
[IOS-2864] Lexical editor - 리스트 아이템의 순번을 잘못 렌더링하는 오류 수정

### DIFF
--- a/Plugins/LexicalListPlugin/LexicalListPlugin/ListNode.swift
+++ b/Plugins/LexicalListPlugin/LexicalListPlugin/ListNode.swift
@@ -21,6 +21,7 @@ extension NodeType {
 public class ListNode: ElementNode {
   enum CodingKeys: String, CodingKey {
     case listType
+    case start
   }
   
   private var listType: ListType = .bullet
@@ -44,6 +45,8 @@ public class ListNode: ElementNode {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.listType = try container.decode(ListType.self, forKey: .listType)
     try super.init(from: decoder)
+
+    self.start = try container.decodeIfPresent(Int.self, forKey: .start) ?? 1
   }
   override public class func getType() -> NodeType {
     return .list


### PR DESCRIPTION
상위 이슈:
- https://linear.app/flexteam/issue/CI-66/홈피드-공지사항-내용이-pc와-모바일에서-다르게-나오는-문제