### PR TITLE
[IOS-3092] TextViewDelegate.textView(_:shouldInteractWith:in:interaction:) 크래시 발생 방지

### DIFF
--- a/Lexical/TextView/TextView.swift
+++ b/Lexical/TextView/TextView.swift
@@ -453,4 +453,9 @@ private class TextViewDelegate: NSObject, UITextViewDelegate {
 
     return textView.lexicalDelegate?.textView(textView, shouldInteractWith: URL, in: characterRange, interaction: interaction) ?? false
   }
+
+  public func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+    // 빈 구현: 크래시 방지용
+    return false
+  }
 }

--- a/Plugins/LexicalLinkPlugin/LexicalLinkPlugin/Nodes/LinkNode.swift
+++ b/Plugins/LexicalLinkPlugin/LexicalLinkPlugin/Nodes/LinkNode.swift
@@ -79,8 +79,22 @@ open class LinkNode: ElementNode {
       return [:]
     }
 
+    // Create a valid URL from the string, and only set the link attribute if valid
     var attribs: [NSAttributedString.Key: Any] = theme.link ?? [:]
-    attribs[.link] = url
+
+    // Check if URL has a scheme, if not, prepend "https://"
+    var urlString = url
+    if !urlString.contains("://") && !urlString.hasPrefix("mailto:") {
+      urlString = "https://" + urlString
+    }
+
+    if let validURL = URL(string: urlString) {
+      attribs[.link] = validURL
+    } else {
+      // If URL cannot be created, use text styling without making it a link
+      // to prevent potential crashes
+    }
+
     return attribs
   }
 


### PR DESCRIPTION
[크래시 리포트](https://app.bugsnag.com/flex-corp/flex-1/errors/68c8b89428f077689139a3da)를 분석해보면, 아래 순서로 함수 호출 후 크래시가 발생했음을 알 수 있습니다.

```
@objc TextViewDelegate.textView(_:shouldInteractWith:in:interaction:)
-> 
static URL._unconditionallyBridgeFromObjectiveC
```

즉, NSURL to URL 브릿징 중 크래시가 발생했다고 가정해봅니다.

---

여러 가지 가능성을 가지고 ChatGPT 와 Claude Code 의 응답을 교차 검증한 뒤, 두 가지 조치를 적용합니다.

1. 함수 signature 가 동일한 다른 인터페이스 구현

UITextViewDelegate 에는 signature 가 완전히 동일한 두 개의 인터페이스가 있습니다.

```
func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool
func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool
```

이 두 인터페이스는 두 번째 파라미터만 서로 다른 파라미터를 받습니다.
현재 코드에서는 이 중 첫 번째 인터페이스만 구현되어 있는데, 두 번째 인터페이스가 호출되어야 할 때 구현부가 없어서 동일한 signature 를 가진 첫 번째 구현이 실행된다고 가정하고, 두 번째 인터페이스도 빈 구현을 채워둡니다.

2. LinkNode 가 반드시 NSURL 이 주입됨을 보장

LexicalLinkPlugin - LinkNode 의 구현 중 NSAttributedString.Key.link 의 값으로 URL 이나 NSURL 이 아닌 String 을 설정하고 있습니다.
이 값을 사전에 검사하여 URL-compatible 한 경우에만 설정하도록 수정합니다.